### PR TITLE
System.in.read doesn't play well with nohup

### DIFF
--- a/src/main/java/org/openhim/mediator/XDSMediatorMain.java
+++ b/src/main/java/org/openhim/mediator/XDSMediatorMain.java
@@ -151,8 +151,6 @@ public class XDSMediatorMain {
         }
 
         log.info(String.format("%s listening on %s:%s", config.getName(), config.getServerHost(), config.getServerPort()));
-        while (true) {
-            System.in.read();
-        }
+        Thread.currentThread().join();
     }
 }


### PR DESCRIPTION
@rcrichton if you could please do a sanity check for me? thanks

This fixes the 100% CPU usage issue. Turns out it was triggered when using nohup.